### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/857/940/89/85794089.geojson
+++ b/data/857/940/89/85794089.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1082677
     },
     "wof:country":"TC",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c320e36fd454715844e377f7d605ce2",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566652661,
+    "wof:lastmodified":1582345772,
     "wof:name":"West Road",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.