### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/535/783/102535783.geojson
+++ b/data/102/535/783/102535783.geojson
@@ -47,6 +47,9 @@
     "name:spa_x_preferred":[
         "Aeropuerto de Caicos del Norte"
     ],
+    "name:tur_x_preferred":[
+        "Kuzey Caicos Havaliman\u0131"
+    ],
     "oa:elevation_ft":"10",
     "oa:type":"medium_airport",
     "src:geom":"ourairports",
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":102535783,
-    "wof:lastmodified":1566652660,
+    "wof:lastmodified":1690868491,
     "wof:name":"North Caicos Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/856/784/09/85678409.geojson
+++ b/data/856/784/09/85678409.geojson
@@ -118,6 +118,9 @@
     "name:tam_x_preferred":[
         "\u0bae\u0bbf\u0b9f\u0bbf\u0bb2\u0bcd \u0b95\u0bbe\u0baf\u0bcd\u0b95\u0bcb\u0bb8\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0bae\u0bbf\u0b9f\u0bbf\u0bb2\u0bcd  \u0b95\u0bbe\u0baf\u0bcd\u0b95\u0bcb\u0bb8\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c3f\u0c21\u0c3f\u0c32\u0c4d \u0c15\u0c48\u0c15\u0c4b\u0c38\u0c4d"
     ],
@@ -251,7 +254,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500667,
+    "wof:lastmodified":1690868491,
     "wof:name":"Middle Caicos",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/856/784/13/85678413.geojson
+++ b/data/856/784/13/85678413.geojson
@@ -121,6 +121,9 @@
     "name:tam_x_preferred":[
         "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1  \u0b95\u0bbe\u0baf\u0bcd\u0b95\u0bcb\u0bb8\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1   \u0b95\u0bbe\u0baf\u0bcd\u0b95\u0bcb\u0bb8\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c28\u0c3e\u0c30\u0c4d\u0c24\u0c4d \u0c15\u0c48\u0c15\u0c4b\u0c38\u0c4d"
     ],
@@ -251,7 +254,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500667,
+    "wof:lastmodified":1690868492,
     "wof:name":"North Caicos",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/890/432/013/890432013.geojson
+++ b/data/890/432/013/890432013.geojson
@@ -28,6 +28,12 @@
     "name:fra_x_preferred":[
         "Cockburn Harbour"
     ],
+    "name:ita_x_preferred":[
+        "Cockburn Harbour"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b3\u30c3\u30af\u30d0\u30fc\u30f3\u30fb\u30cf\u30fc\u30d0\u30fc"
+    ],
     "name:nld_x_preferred":[
         "Cockburn Harbour"
     ],
@@ -58,7 +64,7 @@
         }
     ],
     "wof:id":890432013,
-    "wof:lastmodified":1566652664,
+    "wof:lastmodified":1690868492,
     "wof:name":"Cockburn Harbour",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/440/113/890440113.geojson
+++ b/data/890/440/113/890440113.geojson
@@ -25,6 +25,15 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0643\u0628\u0631\u0646 \u062a\u0627\u0648\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Cockburn Town"
+    ],
+    "name:ary_x_preferred":[
+        "\u0643\u0648\u0643\u0628\u0648\u0631\u0646 \u0637\u0627\u0648\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0643\u0628\u0631\u0646 \u062a\u0627\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "Ciud\u00e1 Cockburn"
     ],
@@ -33,6 +42,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u043e\u0431\u0435\u0440\u043d-\u0422\u0430\u045e\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u043e\u0431\u0435\u0440\u043d-\u0422\u0430\u045e\u043d"
     ],
     "name:bos_x_preferred":[
         "Cockburn Town"
@@ -51,6 +63,9 @@
     ],
     "name:chv_x_preferred":[
         "\u041a\u043e\u0431\u0435\u0440\u043d-\u0422\u0430\u0443\u043d"
+    ],
+    "name:cym_x_preferred":[
+        "Cockburn Town"
     ],
     "name:dan_x_preferred":[
         "Cockburn Town"
@@ -85,6 +100,9 @@
     "name:fry_x_preferred":[
         "Cockburn Town"
     ],
+    "name:gle_x_preferred":[
+        "Cockburn Town"
+    ],
     "name:glg_x_preferred":[
         "Cockburn Town"
     ],
@@ -100,7 +118,13 @@
     "name:hye_x_preferred":[
         "\u0554\u0578\u0584\u0562\u0568\u0580\u0576 \u0539\u0561\u0578\u0582\u0576"
     ],
+    "name:ido_x_preferred":[
+        "Cockburn Town"
+    ],
     "name:ind_x_preferred":[
+        "Cockburn Town"
+    ],
+    "name:isl_x_preferred":[
         "Cockburn Town"
     ],
     "name:ita_x_preferred":[
@@ -157,6 +181,9 @@
     "name:oci_x_preferred":[
         "Cockburn Town"
     ],
+    "name:oss_x_preferred":[
+        "\u041a\u043e\u0431\u0435\u0440\u043d-\u0422\u0430\u0443\u043d"
+    ],
     "name:pms_x_preferred":[
         "Cockburn Town"
     ],
@@ -207,6 +234,9 @@
     ],
     "name:war_x_preferred":[
         "Cockburn Town"
+    ],
+    "name:wuu_x_preferred":[
+        "\u79d1\u4f2f\u6069\u57ce"
     ],
     "name:yor_x_preferred":[
         "Cockburn Town"
@@ -344,7 +374,7 @@
         }
     ],
     "wof:id":890440113,
-    "wof:lastmodified":1566652664,
+    "wof:lastmodified":1690868492,
     "wof:name":"Cockburn Town",
     "wof:parent_id":85678427,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.