### PR TITLE
tc concordances, placetype local, and more

### DIFF
--- a/data/856/784/09/85678409.geojson
+++ b/data/856/784/09/85678409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011724,
-    "geom:area_square_m":134595686.243233,
+    "geom:area_square_m":134595538.34411,
     "geom:bbox":"-71.850657,21.743883,-71.63093,21.856269",
     "geom:latitude":21.80926,
     "geom:longitude":-71.741885,
@@ -25,7 +25,7 @@
     "mps:latitude":21.81663,
     "mps:longitude":-71.752704,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -233,11 +233,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":24549932,
+        "iso:code_pseudo":"TC-03",
         "qs_pg:id":891880,
         "wd:id":"Q1475037"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"TC",
-    "wof:geomhash":"03274e7d0d78b18fad8109418f5bd300",
+    "wof:geomhash":"816ed5bfbb8fcabab02b1e683bc621f8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -254,7 +256,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690868491,
+    "wof:lastmodified":1695884286,
     "wof:name":"Middle Caicos",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/856/784/13/85678413.geojson
+++ b/data/856/784/13/85678413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008546,
-    "geom:area_square_m":98043283.814591,
+    "geom:area_square_m":98043545.580913,
     "geom:bbox":"-72.036244,21.828315,-71.857411,21.959215",
     "geom:latitude":21.908127,
     "geom:longitude":-71.952357,
@@ -25,7 +25,7 @@
     "mps:latitude":21.886396,
     "mps:longitude":-71.931358,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -233,11 +233,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":24549934,
+        "iso:code_pseudo":"TC-04",
         "qs_pg:id":891881,
         "wd:id":"Q174861"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"TC",
-    "wof:geomhash":"a90730ea8ce4fe39ef8782805fe3d478",
+    "wof:geomhash":"29e76ec9294d47d46a32c22b4825bea1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -254,7 +256,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690868492,
+    "wof:lastmodified":1695884286,
     "wof:name":"North Caicos",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/856/784/17/85678417.geojson
+++ b/data/856/784/17/85678417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010566,
-    "geom:area_square_m":121318773.288594,
+    "geom:area_square_m":121318884.374392,
     "geom:bbox":"-72.481313,21.630316,-72.087026,21.885443",
     "geom:latitude":21.780643,
     "geom:longitude":-72.282553,
@@ -25,7 +25,7 @@
     "mps:latitude":21.796832,
     "mps:longitude":-72.272398,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -172,10 +172,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":24549933,
+        "iso:code_pseudo":"TC-05",
         "qs_pg:id":432451
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"TC",
-    "wof:geomhash":"d29b54e5fe6cb303ef352814f6d3bee1",
+    "wof:geomhash":"9d1457a28700c849dda76eed1c8467c1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -192,7 +194,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500666,
+    "wof:lastmodified":1695884286,
     "wof:name":"Providenciales and West Caicos",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/856/784/21/85678421.geojson
+++ b/data/856/784/21/85678421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006383,
-    "geom:area_square_m":73362676.154985,
+    "geom:area_square_m":73362760.084884,
     "geom:bbox":"-71.699086,21.290107,-71.451894,21.766832",
     "geom:latitude":21.644033,
     "geom:longitude":-71.51742,
@@ -25,7 +25,7 @@
     "mps:latitude":21.704514,
     "mps:longitude":-71.485389,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -174,10 +174,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":24549931,
+        "iso:code_pseudo":"TC-06",
         "qs_pg:id":1237239
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"TC",
-    "wof:geomhash":"b1943d0d168d7c307d3b295a756cd225",
+    "wof:geomhash":"54f5fede31111fdaff6700af2d84b519",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -194,7 +196,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500666,
+    "wof:lastmodified":1695884286,
     "wof:name":"South Caicos and East Caicos",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/856/784/27/85678427.geojson
+++ b/data/856/784/27/85678427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00122,
-    "geom:area_square_m":14040019.627891,
+    "geom:area_square_m":14039750.491551,
     "geom:bbox":"-71.151682,21.431627,-71.128896,21.513617",
     "geom:latitude":21.471296,
     "geom:longitude":-71.140156,
@@ -176,10 +176,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":24549929,
+        "iso:code_pseudo":"TC-07",
         "qs_pg:id":352615
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"TC",
-    "wof:geomhash":"53f7f9a3ec821408594423b443094cc4",
+    "wof:geomhash":"2f3daea7692a8fc5d0c02aa6dd6471f1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -196,7 +198,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500666,
+    "wof:lastmodified":1695884873,
     "wof:name":"Grand Turk",
     "wof:parent_id":85632205,
     "wof:placetype":"region",

--- a/data/856/784/31/85678431.geojson
+++ b/data/856/784/31/85678431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000439,
-    "geom:area_square_m":5058563.341701,
+    "geom:area_square_m":5058608.131848,
     "geom:bbox":"-71.219228,21.310614,-71.192494,21.341376",
     "geom:latitude":21.327953,
     "geom:longitude":-71.2072,
@@ -188,10 +188,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":24549930,
+        "iso:code_pseudo":"TC-08",
         "qs_pg:id":352616
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"TC",
-    "wof:geomhash":"2857548eb98c88a64684aa88095dd91a",
+    "wof:geomhash":"f3bb024482397abee30394fadb366684",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -208,7 +210,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500667,
+    "wof:lastmodified":1695884873,
     "wof:name":"Salt Cay",
     "wof:parent_id":85632205,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.